### PR TITLE
Switch the code block ends in place, rather than copying the whole buffer into a string

### DIFF
--- a/literate.el
+++ b/literate.el
@@ -71,7 +71,7 @@
     (rewrite-ends "#+BEGIN_SRC org-agda" "#+END_SRC" "\\begin{code}" "\\end{code}")
     (rewrite-ends "#+BEGIN_EXAMPLE org-agda" "#+END_EXAMPLE" "\\begin{spec}" "\\end{spec}")
     (agda2-mode)
-    (sit-for 1) ;; necessary for the slight delay between the agda2 commands
+    (sit-for 0.1) ;; necessary for the slight delay between the agda2 commands
     (agda2-load)
     (goto-line here-line)
     (move-to-column here-column)

--- a/literate.el
+++ b/literate.el
@@ -50,12 +50,14 @@
    Use haskell as the Org source block language since I do not have nice colouring otherwise.
   "
   (interactive)
-  (let ((here (line-number-at-pos))) ;; remember current line
+  (let ((here-line (line-number-at-pos)) ;; remember current line
+	(here-column (current-column)))
     (rewrite-ends "\\begin{code}" "\\end{code}" "#+BEGIN_SRC org-agda" "#+END_SRC")
     (rewrite-ends "\\begin{spec}" "\\end{spec}" "#+BEGIN_EXAMPLE org-agda" "#+END_EXAMPLE")
     ;; (sit-for 2) ;; necessary for the slight delay between the agda2 commands
     (org-mode)
-    (org-goto-line here)    ;; personal function, see my init.org
+    (org-goto-line here-line) ;; defined above
+    (move-to-column here-column)
   )
 )
 
@@ -64,13 +66,15 @@
    Use haskell as the Org source block language since I do not have nice colouring otherwise.
   "
   (interactive)
-  (let ((here (line-number-at-pos))) ;; remember current line
+  (let ((here-line (line-number-at-pos)) ;; remember current line
+	(here-column (current-column)))  ;; and current column
     (rewrite-ends "#+BEGIN_SRC org-agda" "#+END_SRC" "\\begin{code}" "\\end{code}")
     (rewrite-ends "#+BEGIN_EXAMPLE org-agda" "#+END_EXAMPLE" "\\begin{spec}" "\\end{spec}")
     (agda2-mode)
     (sit-for 1) ;; necessary for the slight delay between the agda2 commands
     (agda2-load)
-    (goto-line here)
+    (goto-line here-line)
+    (move-to-column here-column)
   )
 )
 

--- a/literate.el
+++ b/literate.el
@@ -52,8 +52,8 @@
   "
   (interactive)
   (let ((here (line-number-at-pos))) ;; remember current line
-    (rewrite-ends "\\begin{code}\n" "\n\\end{code}" "#+BEGIN_SRC org-agda\n" "\n#+END_SRC")
-    (rewrite-ends "\\begin{spec}\n" "\n\\end{spec}" "#+BEGIN_EXAMPLE org-agda\n" "\n#+END_EXAMPLE")
+    (rewrite-ends "\\begin{code}" "\\end{code}" "#+BEGIN_SRC org-agda" "#+END_SRC")
+    (rewrite-ends "\\begin{spec}" "\\end{spec}" "#+BEGIN_EXAMPLE org-agda" "#+END_EXAMPLE")
     ;; (sit-for 2) ;; necessary for the slight delay between the agda2 commands
     (org-mode)
     (org-goto-line here)    ;; personal function, see my init.org
@@ -66,8 +66,8 @@
   "
   (interactive)
   (let ((here (line-number-at-pos))) ;; remember current line
-    (rewrite-ends "#+BEGIN_SRC org-agda\n" "#+END_SRC" "\\begin{code}\n" "\\end{code}")
-    (rewrite-ends "#+BEGIN_EXAMPLE org-agda\n" "#+END_EXAMPLE" "\\begin{spec}\n" "\\end{spec}")
+    (rewrite-ends "#+BEGIN_SRC org-agda" "#+END_SRC" "\\begin{code}" "\\end{code}")
+    (rewrite-ends "#+BEGIN_EXAMPLE org-agda" "#+END_EXAMPLE" "\\begin{spec}" "\\end{spec}")
     (agda2-mode)
     (sit-for 1) ;; necessary for the slight delay between the agda2 commands
     (agda2-load)

--- a/literate.el
+++ b/literate.el
@@ -3,6 +3,7 @@
 ;; Changes:
 ;; - rewrote rewrite ends
 ;; - inserted org-goto-line
+;; - made the mode switch a toggle bound to C-x C-a
 
 (defun org-goto-line (line)
   "Go to the indicated line, unfolding the parent Org header.
@@ -74,7 +75,7 @@
   )
 )
 
-(local-set-key (kbd "C-x C-a") 'org-to-lagda)
-(local-set-key (kbd "C-x C-o") 'lagda-to-org)
-
-;; Maybe consider a simple “toggle” instead?
+(add-hook 'org-mode-hook
+          (lambda () (local-set-key (kbd "C-x C-a") 'org-to-lagda)))
+(add-hook 'agda2-mode-hook
+          (lambda () (local-set-key (kbd "C-x C-a") 'lagda-to-org)))

--- a/literate.el
+++ b/literate.el
@@ -1,4 +1,4 @@
-;; This file is generated from literate.lagda.
+;; This file has diverged from literate.lagda.
 
 (defun rewrite-ends (pre post new-pre new-post)
   "Perform the following in-buffer rewrite: ⟨pre⟩⋯⟨post⟩ ↦ ⟨newPre⟩⋯⟨newPost⟩.

--- a/literate.el
+++ b/literate.el
@@ -1,4 +1,22 @@
 ;; This file has diverged from literate.lagda.
+;;
+;; Changes:
+;; - rewrote rewrite ends
+;; - inserted org-goto-line
+
+(defun org-goto-line (line)
+  "Go to the indicated line, unfolding the parent Org header.
+
+   Implementation: Go to the line, then look at the 1st previous
+   org header, now we can unfold it whence we do so, then we go
+   back to the line we want to be at.
+  "
+  (interactive)
+  (goto-line line)
+  (org-previous-visible-heading 1)
+  (org-cycle)
+  (goto-line line)
+)
 
 (defun rewrite-ends (pre post new-pre new-post)
   "Perform the following in-buffer rewrite: ⟨pre⟩⋯⟨post⟩ ↦ ⟨newPre⟩⋯⟨newPost⟩.

--- a/literate.el
+++ b/literate.el
@@ -12,12 +12,11 @@
    org header, now we can unfold it whence we do so, then we go
    back to the line we want to be at.
   "
-  (interactive)
   (goto-line line)
-  (org-previous-visible-heading 1)
+  (org-back-to-heading 1)
   (org-cycle)
   (goto-line line)
-)
+  )
 
 (defun rewrite-ends (pre post new-pre new-post)
   "Perform the following in-buffer rewrite: ⟨pre⟩⋯⟨post⟩ ↦ ⟨newPre⟩⋯⟨newPost⟩.

--- a/literate.el
+++ b/literate.el
@@ -1,9 +1,4 @@
-;; This file has diverged from literate.lagda.
-;;
-;; Changes:
-;; - rewrote rewrite ends
-;; - inserted org-goto-line
-;; - made the mode switch a toggle bound to C-x C-a
+;; This file is generated from literate.lagda.
 
 (defun org-goto-line (line)
   "Go to the indicated line, unfolding the parent Org header.
@@ -44,7 +39,6 @@
     )
   )
 
-
 (defun lagda-to-org ()
   "Transform literate Agda blocks into Org-mode source blocks.
    Use haskell as the Org source block language since I do not have nice colouring otherwise.
@@ -52,9 +46,10 @@
   (interactive)
   (let ((here-line (line-number-at-pos)) ;; remember current line
 	(here-column (current-column)))
-    (rewrite-ends "\\begin{code}" "\\end{code}" "#+BEGIN_SRC org-agda" "#+END_SRC")
-    (rewrite-ends "\\begin{spec}" "\\end{spec}" "#+BEGIN_EXAMPLE org-agda" "#+END_EXAMPLE")
-    ;; (sit-for 2) ;; necessary for the slight delay between the agda2 commands
+    (rewrite-ends "\n\\begin{code}"              "\n\\end{code}"
+                  "\n#+BEGIN_SRC org-agda"       "\n#+END_SRC")
+    (rewrite-ends "\n\\begin{spec}"              "\n\\end{spec}"
+                  "\n#+BEGIN_EXAMPLE org-agda"   "\n#+END_EXAMPLE")
     (org-mode)
     (org-goto-line here-line) ;; defined above
     (move-to-column here-column)
@@ -68,8 +63,10 @@
   (interactive)
   (let ((here-line (line-number-at-pos)) ;; remember current line
 	(here-column (current-column)))  ;; and current column
-    (rewrite-ends "#+BEGIN_SRC org-agda" "#+END_SRC" "\\begin{code}" "\\end{code}")
-    (rewrite-ends "#+BEGIN_EXAMPLE org-agda" "#+END_EXAMPLE" "\\begin{spec}" "\\end{spec}")
+    (rewrite-ends "\n#+BEGIN_SRC org-agda"       "\n#+END_SRC"
+                  "\n\\begin{code}"              "\n\\end{code}")
+    (rewrite-ends "\n#+BEGIN_EXAMPLE org-agda"   "\n#+END_EXAMPLE"
+                  "\n\\begin{spec}"              "\n\\end{spec}")
     (agda2-mode)
     (sit-for 0.1) ;; necessary for the slight delay between the agda2 commands
     (agda2-load)

--- a/literate.el
+++ b/literate.el
@@ -1,37 +1,31 @@
 ;; This file is generated from literate.lagda.
 
-;; “The long lost Emacs string manipulation library”
-;; https://github.com/magnars/s.el
-(require 's)
-
-(defun strip (pre post it)  
-  "A simple extraction: it = ⟨pre⟩it₀⟨post⟩ ↦ it₀." 
-  (s-chop-prefix pre (s-chop-suffix post it)) )
-
-(defun rewrite-ends (pre post newPre newPost)
+(defun rewrite-ends (pre post new-pre new-post)
   "Perform the following in-buffer rewrite: ⟨pre⟩⋯⟨post⟩ ↦ ⟨newPre⟩⋯⟨newPost⟩.
   For example, for rewriting begin-end code blocks from Org-mode to something
   else, say a language's default literate mode.
 
-  Warning: The body, the “⋯”, cannot contain the `#` character.
-  I do this so that the search does not go to the very last occurence of `#+END_SRC`;
-  which is my primary instance of `pre`.
+  The search for the string ⟨pre⟩⋯⟨post⟩ is non-greedy, i.e. will find
+  (in order) the minimal strings matching ⟨pre⟩⋯⟨post⟩.
 
   In the arguments, only symbol `\` needs to be escaped.
-
-  Implementation: Match the pre, then any characteer that is not `#`, then the post.
-  Hence, the body cannot contain a `#` character!
-  In Agda this is not an issue, since we can use its Unicode cousin `♯` instead.
   "
-  (let* ((rxPre     (regexp-quote pre))
-         (rxPost    (regexp-quote post))
-         (altered (replace-regexp-in-string (concat rxPre "\\([^\\#]\\|\n\\)*" rxPost)
-                  (lambda (x) (concat newPre (strip pre post x) newPost))
-                  (buffer-string) 'no-fixed-case 'new-text-is-literal)))
-      (erase-buffer)
-      (insert altered)
-   )
-)
+  (let ((rx-pre  (concat "\\(" (regexp-quote pre)  "\\)"))
+        (rx-post (concat "\\(" (regexp-quote post) "\\)"))
+        ;; Code to match any characters (including newlines) based on https://www.emacswiki.org/emacs/MultilineRegexp
+        ;; This version requires we end in a newline,
+        ;; and uses the “non-greedy” * operator, *?, so we will match the minimal string.
+        (body "\\(.*\n\\)*?"))
+    (beginning-of-buffer)
+    (while (re-search-forward (concat rx-pre body rx-post) nil t) ;; nil to search whole buffer, t to not error
+      ;; Matched string 1 is the pre, matched string 3 is the post.
+      ;; Optionals: fixed-case, literal, use buffer, substring
+      (replace-match new-pre  t t nil 1)
+      (replace-match new-post t t nil 3)
+      )
+    )
+  )
+
 
 (defun lagda-to-org ()
   "Transform literate Agda blocks into Org-mode source blocks.

--- a/org-agda-mode.el
+++ b/org-agda-mode.el
@@ -28,33 +28,33 @@
 (define-generic-mode
     'org-agda-mode                      ;; name of the mode
     (list '("{-" . "-}"))               ;; comments delimiter
-    org-agda-keywords    
-    ;; font lock list: Order of colouring matters; 
+    org-agda-keywords
+    ;; font lock list: Order of colouring matters;
     ;; the numbers refer to the subpart, or the whole(0), that should be coloured.
     (list
      ;; To begin with, after "module" or after "import" should be purple
      ;; Note the SPACE below.
-     '("\\(module\\|import\\) \\([a-zA-Z0-9\-_\.]+\\)" 2 '((t (:foreground "purple")))) 
-     
+     '("\\(module\\|import\\) \\([a-zA-Z0-9\-_\.]+\\)" 2 '((t (:foreground "purple"))))
+
      ;; Agda special symbols: as
      '(" as" 0 'agda2-highlight-symbol-face)
-     
+
      ;; Type, and constructor, names begin with a capital letter  --personal convention.
-     ;; They're preceded by either a space or an open delimiter character. 
+     ;; They're preceded by either a space or an open delimiter character.
      '("\\( \\|\s(\\)\\([A-Z]+\\)\\([a-zA-Z0-9\-_]*\\)" 0 'font-lock-type-face)
      '("ℕ" 0 'font-lock-type-face)
-     
+
      ;; variables & function names, as a personal convention, begin with a lower case
      '("\\([a-z]+\\)\\([a-zA-Z0-9\-_]*\\)" 0 '((t (:foreground "medium blue"))))
-     
+
      ;; colour numbers
      '("\\([0-9]+\\)" 1   '((t (:foreground "purple")))) ;; 'font-lock-constant-face)
-     
+
      ;; other faces to consider:
      ;; 'font-lock-keyword-face 'font-lock-builtin-face 'font-lock-function-name-face
      ;;' font-lock-variable-name-face
      )
-    
+
      nil                                                   ;; files that trigger this mode
      nil                                                   ;; any other functions to call
     "My custom Agda highlighting mode for use *within* Org-mode."     ;; doc string


### PR DESCRIPTION
Makes use of lazy regular expressions.