### PR TITLE
Use require instead of use-package

### DIFF
--- a/org-agda-mode.el
+++ b/org-agda-mode.el
@@ -1,6 +1,6 @@
 (provide 'org-agda-mode)
 
-(use-package polymode)
+(require 'polymode)
 
 (define-hostmode poly-org-agda-hostmode
   :mode 'org-mode


### PR DESCRIPTION
The package will not load for me without this change. I haven't seen use-package being used within a package definition before.